### PR TITLE
chore: replace TensoRaws org URLs with EutropicAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following references were used in the development of this project:
 
 After v3.0.0, ncnn will be deprecated, and the project will use ccrestoration(PyTorch) as the algorithm implementation.
 
-- [ccrestoration](https://github.com/TensoRaws/ccrestoration)
+- [ccrestoration](https://github.com/EutropicAI/ccrestoration)
 - [PyTorch](https://github.com/pytorch/pytorch)
 
 ---


### PR DESCRIPTION
We renamed the organization. This PR updates occurrences of:
- https://github.com/TensoRaws
to:
- https://github.com/EutropicAI

Notes:
- Only text-like files were modified; common binary/build paths skipped.
- Please review and merge when ready.
